### PR TITLE
Switch to Chart

### DIFF
--- a/app/ode-examples/Main.hs
+++ b/app/ode-examples/Main.hs
@@ -2,8 +2,8 @@
 {-# LANGUAGE DataKinds #-}
 module Main where
 
-import qualified Graphics.Gnuplot.Simple as Gnuplot
-import qualified Graphics.Gnuplot.Terminal.SVG as SVG
+import qualified Graphics.Rendering.Chart.Easy as Chart
+import qualified Graphics.Rendering.Chart.Backend.Diagrams as ChartDiagrams
 import qualified Data.Maybe as Maybe
 import qualified Data.Vector.Unboxed.Sized as USized
 
@@ -17,16 +17,17 @@ shm :: IO ()
 shm = do
   let
     state0 = Maybe.fromJust $ USized.fromList [ 1.0, 0.0 ]
-    integResult = ODE.odeFixedSteps ODE.eulerStep [0.0, 0.1 .. 5.0] state0 shmfn
+    integResult = ODE.odeFixedSteps ODE.eulerStep [0.0, 0.01 .. 15.0] state0 shmfn
     plotValues = fmap (\(t, v) -> (t, USized.index v 0)) integResult
   putStrLn "Hello World"
-  Gnuplot.plotList [Gnuplot.terminal (SVG.cons "test.svg")] plotValues
+  ChartDiagrams.toFile Chart.def "test.svg" $ do
+    Chart.plot (Chart.line "integrated" [plotValues])
 
 shmfn :: (Double, USized.Vector 2 Double) -> USized.Vector 2 Double
 shmfn (_, s) = Maybe.fromJust $ USized.fromList [ v, -k * x / m ]
   where
     m = 1.0
-    k = 1.0
+    k = 3.0
     x = USized.index s 0
     v = USized.index s 1
 

--- a/package.yaml
+++ b/package.yaml
@@ -21,7 +21,8 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
 - base >= 4.7 && < 5
-- gnuplot
+- Chart
+- Chart-diagrams
 - vector
 - vector-sized
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-13.6
+resolver: lts-12.26
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -48,6 +48,12 @@ packages:
 #   - chart-cairo
 # - cairo-0.13.6.0
 # - gtk2hs-buildtools-0.13.5.0
+extra-deps:
+- indexed-list-literals-0.2.1.2
+- vector-sized-1.2.0.0
+- Chart-1.9
+- Chart-diagrams-1.9
+- SVGFonts-1.6.0.3
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
- Revert back to an earlier LTS
- Push vector-sized to the version in the *current* LTS
- Include Chart, Chart-diagrams and SVGFonts in extra-deps