### PR TITLE
Bump stackage version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ language: generic
 cache:
   directories:
   - $HOME/.stack
-  - $HOME/lancelet/space-workshop/.stack-work/install
 
 # Ensure necessary system libraries are present
 addons:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.18
+resolver: lts-13.19
 packages:
 - .
 extra-deps:


### PR DESCRIPTION
- Bump stackage to LTS-13.19
- Don't cache .stack-work directory; doesn't seem to be working